### PR TITLE
Fix module resolution for windows

### DIFF
--- a/lib/createClient.js
+++ b/lib/createClient.js
@@ -10,7 +10,7 @@ var schemas = fs.readdirSync(path.join(__dirname, dirName));
 module.exports = function (requester, requestCallbackHandler, host) {
   return _.chain(schemas).map(function (filename) {
     var methodName = filename.split('.')[0];
-    var schema = require('.' + path.sep + dirName + path.sep + methodName);
+    var schema = require('./' + dirName + '/' + methodName);
 
     return [methodName, genericClientComposer(schema, requester, requestCallbackHandler, host)];
   }).fromPairs().value();


### PR DESCRIPTION
on windows it was not able to resolve the modules as a backslash ends up escaping the string. windows does not require a backlash in order for require to resolve the modules